### PR TITLE
Optimise HMGET method

### DIFF
--- a/library.c
+++ b/library.c
@@ -3527,26 +3527,37 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
         } else {
             add_next_index_bool(z_tab, 0);
         }
-        goto failure;
+        // Cleanup z_keys
+        for (i = 0; Z_TYPE(z_keys[i]) != IS_NULL; ++i) {
+            zval_dtor(&z_keys[i]);
+        }
+        efree(z_keys);
+        return FAILURE;
     }
+
     zval z_multi_result;
-    array_init(&z_multi_result); /* pre-allocate array for multi's results. */
+
+    array_init_size(&z_multi_result, numElems); /* pre-allocate array for multi's results. */
 
     for(i = 0; i < numElems; ++i) {
-        zend_string *zstr = zval_get_string(&z_keys[i]);
+        zend_string *tmp_str;
+        zend_string *zstr = zval_get_tmp_string(&z_keys[i], &tmp_str);
         response = redis_sock_read(redis_sock, &response_len);
-        if(response != NULL) {
-            zval z_unpacked;
-            if (redis_unpack(redis_sock, response, response_len, &z_unpacked)) {
-                add_assoc_zval_ex(&z_multi_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), &z_unpacked);
-            } else {
-                add_assoc_stringl_ex(&z_multi_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), response, response_len);
+        zval z_unpacked;
+        if (response != NULL) {
+            if (!redis_unpack(redis_sock, response, response_len, &z_unpacked)) {
+                ZVAL_STRINGL(&z_unpacked, response, response_len);
             }
             efree(response);
         } else {
-            add_assoc_bool_ex(&z_multi_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), 0);
+            ZVAL_FALSE(&z_unpacked);
         }
-        zend_string_release(zstr);
+        zend_symtable_update(Z_ARRVAL(z_multi_result), zstr, &z_unpacked);
+        zend_tmp_string_release(tmp_str);
+    }
+
+    // Cleanup z_keys
+    for (i = 0; Z_TYPE(z_keys[i]) != IS_NULL; ++i) {
         zval_dtor(&z_keys[i]);
     }
     efree(z_keys);
@@ -3557,14 +3568,6 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
         add_next_index_zval(z_tab, &z_multi_result);
     }
     return SUCCESS;
-failure:
-    if (z_keys != NULL) {
-        for (i = 0; Z_TYPE(z_keys[i]) != IS_NULL; ++i) {
-            zval_dtor(&z_keys[i]);
-        }
-        efree(z_keys);
-    }
-    return FAILURE;
 }
 
 /**

--- a/library.c
+++ b/library.c
@@ -3534,6 +3534,8 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 
     array_init_size(&z_multi_result, numElems); /* pre-allocate array for multi's results. */
 
+    printf("redis_mbulk_reply_assoc\n");
+
     for(i = 0; i < numElems; ++i) {
         response = redis_sock_read(redis_sock, &response_len);
         zval z_value;
@@ -3553,6 +3555,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
     }
 
     // Cleanup z_keys
+    printf("redis_mbulk_reply_assoc Cleanup z_keys\n");
     for (i = 0; z_keys[i] != NULL; ++i) {
         zend_string_release(z_keys[i]);
     }

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2693,7 +2693,7 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         redis_cmd_append_sstr_zstr(&cmdstr, zctx[i]);
     }
 
-    printf("redis_hmget_cmd command: %s\n", cmdstr.c);
+    printf("redis_hmget_cmd command: %.*s\n", (int)cmdstr.len, cmdstr.c);
 
     // Push out command, length, and key context
     *cmd     = cmdstr.c;

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2649,6 +2649,8 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     char **cmd, int *cmd_len, short *slot, void **ctx)
 {
+    printf("redis_hmget_cmd\n");
+
     zval *field = NULL;
     zend_string **zctx = NULL;
     smart_string cmdstr = {0};
@@ -2690,6 +2692,8 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     for (i = 0; i < valid; i++) {
         redis_cmd_append_sstr_zstr(&cmdstr, zctx[i]);
     }
+
+    printf("redis_hmget_cmd command: %s\n", cmdstr.c);
 
     // Push out command, length, and key context
     *cmd     = cmdstr.c;


### PR DESCRIPTION
Allocate output array to expected size and reuse already allocated string for output array keys